### PR TITLE
fix: proper os.Stat error handling in fileExists (avoid nil deref). Fix #9

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,14 +26,21 @@ func log2exit(retval int, msg string) {
 /*
 Reference: https://golangcode.com/check-if-a-file-exists/
 FIXME: The source article was down.
+
+Changed: fileExists now returns (bool, error).
+For any os.Stat error (including file-not-exist), the function returns
+false plus an error with the message "file non-exist or error: ...".
+This avoids dereferencing a nil FileInfo when os.Stat returns a non-nil error.
 */
-func fileExists(filename string) bool {
+func fileExists(filename string) (bool, error) {
 	info, err := os.Stat(filename)
-	if os.IsNotExist(err) {
-		return false
+	if err != nil {
+		// Combine all errors (not found, permission, I/O, etc.) into a single case
+		// and return a descriptive error as requested.
+		return false, fmt.Errorf("file non-exist or error: %v", err)
 	}
-	/* FIXME: The file may be regular ot not */
-	return !info.IsDir()
+	/* FIXME: The file may be regular or not */
+	return !info.IsDir(), nil
 }
 
 func args2cmd(args []string) (string, []string) {
@@ -100,7 +107,7 @@ func main() {
 		log2exit(1, ":: Error: Cluster name must be something like :foo.\n")
 	}
 	if cluster_name[0:1] != ":" {
-		log2exit(1, fmt.Sprintf(":: Error: Cluster name (context) must be prefixed with `:', e.g., gk8s :%s.\n", cluster_name))
+		log2exit(1, fmt.Sprintf(":: Error: Cluster name (context) must be prefixed with `:' , e.g., gk8s :%s.\n", cluster_name))
 	}
 	cluster_name = cluster_name[1:]
 
@@ -130,14 +137,19 @@ func main() {
 		kubecfg = filepath.Join(home, ".kube/config")
 	}
 
-	if !fileExists(kubecfg) {
-		log2exit(127, fmt.Sprintf(":: KUBECONFIG file not found: %s\n", kubecfg))
+	// Use new fileExists signature
+	exists, err := fileExists(kubecfg)
+	if err != nil {
+		log2exit(127, fmt.Sprintf(":: KUBECONFIG file not found or stat error: %v\n", err))
+	}
+	if !exists {
+		log2exit(127, fmt.Sprintf(":: Error: KUBECONFIG %s is not a regular file.\n", kubecfg))
 	}
 
 	os.Setenv("KUBECONFIG", kubecfg)
-	log2(fmt.Sprintf(":: Executing '%s', args: %v, KUBECONFIG: %s\n", binary, args, kubecfg))
-	err := syscall.Exec(binary, args, syscall.Environ())
+	log2(fmt.Sprintf(":: Executing '%s', args: %%v, KUBECONFIG: %%s\n", binary, args, kubecfg))
+	err = syscall.Exec(binary, args, syscall.Environ())
 	if err != nil {
-		log2exit(1, fmt.Sprintf(":: Error: %v.\n", err))
+		log2exit(1, fmt.Sprintf(":: Error: %%v.\n", err))
 	}
 }

--- a/main.go
+++ b/main.go
@@ -144,7 +144,7 @@ func main() {
 	}
 
 	os.Setenv("KUBECONFIG", kubecfg)
-	log2(fmt.Sprintf(":: Executing '%s', args: %v, KUBECONFIG: %%s\n", binary, args, kubecfg))
+	log2(fmt.Sprintf(":: Executing '%s', args: %v, KUBECONFIG: %s\n", binary, args, kubecfg))
 	err = syscall.Exec(binary, args, syscall.Environ())
 	if err != nil {
 		log2exit(1, fmt.Sprintf(":: Error: %v.\n", err))

--- a/main.go
+++ b/main.go
@@ -139,17 +139,14 @@ func main() {
 
 	// Use new fileExists signature
 	exists, err := fileExists(kubecfg)
-	if err != nil {
+	if err != nil || !exists {
 		log2exit(127, fmt.Sprintf(":: KUBECONFIG file not found or stat error: %v\n", err))
-	}
-	if !exists {
-		log2exit(127, fmt.Sprintf(":: Error: KUBECONFIG %s is not a regular file.\n", kubecfg))
 	}
 
 	os.Setenv("KUBECONFIG", kubecfg)
-	log2(fmt.Sprintf(":: Executing '%s', args: %%v, KUBECONFIG: %%s\n", binary, args, kubecfg))
+	log2(fmt.Sprintf(":: Executing '%s', args: %v, KUBECONFIG: %%s\n", binary, args, kubecfg))
 	err = syscall.Exec(binary, args, syscall.Environ())
 	if err != nil {
-		log2exit(1, fmt.Sprintf(":: Error: %%v.\n", err))
+		log2exit(1, fmt.Sprintf(":: Error: %v.\n", err))
 	}
 }

--- a/tests.sh
+++ b/tests.sh
@@ -198,11 +198,11 @@ default() {
       "The noop command just does nothing"
 
   _test _fail_with_cluster_config_not_found \
-      "KUBECONFIG file not found:" \
+      "KUBECONFIG file not found or stat error:" \
       "Return immediately when kubecfg file not found."
 
   _test _fail_with_local_and_cluster_config_not_found \
-      "(Command not found)|(KUBECONFIG file not found:)|(The connection to the server localhost:8080 was refused)" \
+      "(Command not found)|(KUBECONFIG file not found or stat error:)|(The connection to the server localhost:8080 was refused)" \
       "Return when cluster configuration doesn't work"
 
   _test _ok_with_fake_kubectl_get_pods \


### PR DESCRIPTION
Contents below generated by Copilot (gpt-5-mini)

1. The MR is completely created by AI. Test cases fixed by @icy 
2. Problem: fileExists previously ignored os.Stat errors except for os.IsNotExist(err) and then dereferenced info.IsDir() even when info was nil, which causes a nil-pointer dereference when os.Stat returns a non-nil error that is not ErrNotExist (permission errors, transient FS errors, etc.).
3. Fix: fileExists now returns (bool, error). For any os.Stat error (including file-not-exist) the function returns false and a single combined error message ("file non-exist or error: ..."). The caller in main checks the returned error first and fails with a clear message. This avoids dereferencing a nil FileInfo and makes the behavior explicit.
4. Rationale: combining all os.Stat errors into a single case matches the user's request ("For any error, return file non-exist or error (combine all error into a single case)"), simplifies caller logic, and prevents runtime panics.
5. Tests / next steps: we recommend adding unit tests that simulate os.Stat returning ErrNotExist and permission errors to prevent regressions. Optionally change fileExists to return richer typed errors if finer-grained handling is desired later.
